### PR TITLE
(#28) minimalize post footer content on mobile

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -830,6 +830,16 @@ a.search_subreddit:hover {
 	margin-right: 15px;
 }
 
+#post_links > li.desktop_item {
+	display: auto;
+}
+
+@media screen and (min-width: 480px) {
+	#post_links > li.mobile_item {
+		display: none;
+	}
+}
+
 .post_thumbnail {
 	border-radius: 5px;
 	border: var(--panel-border);
@@ -1411,4 +1421,9 @@ td, th {
 		padding: 7px 0px;
 		margin-right: -5px;
 	}
+
+	#post_links > li { margin-right: 10px }
+	#post_links > li.desktop_item { display: none }
+	#post_links > li.mobile_item { display: auto }
+	.post_footer > p > span#upvoted { display: none }
 }

--- a/templates/utils.html
+++ b/templates/utils.html
@@ -150,13 +150,16 @@
 	<div class="post_score" title="{{ post.score.1 }}">{{ post.score.0 }}<span class="label"> Upvotes</span></div>
 	<div class="post_footer">
 		<ul id="post_links">
-			<li><a href="{{ post.permalink }}">permalink</a></li>
+			<li class="desktop_item"><a href="{{ post.permalink }}">permalink</a></li>
+			<li class="mobile_item"><a href="{{ post.permalink }}">link</a></li>
 			{% if post.num_duplicates > 0 %}
-			<li><a href="/r/{{ post.community }}/duplicates/{{ post.id }}">duplicates</a></li>
+			<li class="desktop_item"><a href="/r/{{ post.community }}/duplicates/{{ post.id }}">duplicates</a></li>
+			<li class="mobile_item"><a href="/r/{{ post.community }}/duplicates/{{ post.id }}">dupes</a></li>
 			{% endif %}
-			<li><a href="https://reddit.com{{ post.permalink }}" rel="nofollow">reddit</a></li>
+			<li class="desktop_item"><a href="https://reddit.com{{ post.permalink }}" rel="nofollow">reddit</a></li>
+			<li class="mobile_item"><a href="https://reddit.com{{ post.permalink }}" rel="nofollow">reddit</a></li>
 		</ul>
-		<p>{{ post.upvote_ratio }}% Upvoted</p>
+		<p>{{ post.upvote_ratio }}%<span id="upvoted"> Upvoted</span></p>
 	</div>
 </div>
 {%- endmacro %}


### PR DESCRIPTION
This PR modifies the post macro in `templates/utils.html` to minimalize the text on the post footer so that the content doesn't overflow and/or collide, as observed in #28. Thus, this would fix #28. (That last sentence is to convince GitHub to identify this PR with that issue.)

![](https://user-images.githubusercontent.com/13266270/194996177-1f0030d5-e223-40d0-8e1b-fc69f7b4ef4f.png)
